### PR TITLE
Rewrite

### DIFF
--- a/src/Deferred.coffee
+++ b/src/Deferred.coffee
@@ -1,9 +1,9 @@
-### 
+###
 Standalone Deferred
-Copyright 2012 Otto Vehviläinen 
+Copyright 2012 Otto Vehviläinen
 Released under MIT license
 
-This is a standalone implementation of the wonderful jQuery.Deferred API. 
+This is a standalone implementation of the wonderful jQuery.Deferred API.
 The documentation here is only for quick reference, for complete api please
 see the great work of the original project:
 
@@ -31,19 +31,19 @@ Removes elements that are not functions
 flatten = (args) ->
   return [] unless args
   flatted = []
-  args.forEach (item) -> 
+  args.forEach (item) ->
     if item
       if typeof item == 'function'
         flatted.push(item)
       else
-        args.forEach (fn) -> 
+        args.forEach (fn) ->
           if typeof fn == 'function'
             flatted.push(fn)
   flatted
 
 
 ###
-Promise object functions as a proxy for a Deferred, except 
+Promise object functions as a proxy for a Deferred, except
 it does not let you modify the state of the Deferred
 ###
 class Promise
@@ -75,19 +75,19 @@ class Promise
     this
 
 class root.Deferred
-  
+
   ###
-  Initializes a new Deferred. You can pass a function as a parameter 
-  to be executed immediately after init. The function receives 
+  Initializes a new Deferred. You can pass a function as a parameter
+  to be executed immediately after init. The function receives
   the new deferred object as a parameter and this is also set to the
   same object.
-  ### 
+  ###
   constructor: (fn) ->
     @_state = 'pending'
     fn.call(this, this) if typeof fn == 'function'
-  
+
   ###
-  Pass in functions or arrays of functions to be executed when the 
+  Pass in functions or arrays of functions to be executed when the
   Deferred object changes state from pending. If the state is already
   rejected or resolved, the functions are executed immediately. They
   receive the arguments that are passed to reject or resolve and this
@@ -104,12 +104,12 @@ class root.Deferred
       functions.forEach (fn) =>
         fn.apply(@_context, @_withArguments)
     this
-  
+
   ###
-  Pass in functions or arrays of functions to be executed when the 
-  Deferred object is resolved. If the object has already been resolved, 
+  Pass in functions or arrays of functions to be executed when the
+  Deferred object is resolved. If the object has already been resolved,
   the functions are executed immediately. If the object has been rejected,
-  nothing happens. The functions receive the arguments that are passed 
+  nothing happens. The functions receive the arguments that are passed
   to resolve and this is set to the object defined by resolveWith if that
   variant is used.
   ###
@@ -123,12 +123,12 @@ class root.Deferred
       @_doneCallbacks or= []
       @_doneCallbacks.push(functions...)
     this
-  
+
   ###
-  Pass in functions or arrays of functions to be executed when the 
-  Deferred object is rejected. If the object has already been rejected, 
+  Pass in functions or arrays of functions to be executed when the
+  Deferred object is rejected. If the object has already been rejected,
   the functions are executed immediately. If the object has been resolved,
-  nothing happens. The functions receive the arguments that are passed 
+  nothing happens. The functions receive the arguments that are passed
   to reject and this is set to the object defined by rejectWith if that
   variant is used.
   ###
@@ -142,7 +142,7 @@ class root.Deferred
       @_failCallbacks or= []
       @_failCallbacks.push(functions...)
     this
-  
+
   ###
   Notify progress callbacks. The callbacks get passed the arguments given to notify.
   If the object has resolved or rejected, nothing will happen
@@ -150,7 +150,7 @@ class root.Deferred
   notify: (args...) ->
     @notifyWith(root, args...)
     this
-  
+
   ###
   Notify progress callbacks with additional context. Works the same way as notify(),
   except this is set to context when calling the functions.
@@ -159,11 +159,11 @@ class root.Deferred
     return this if @_state != 'pending'
     @_progressCallbacks?.forEach (fn) ->
       fn.apply(context, args)
-    this  
-  
+    this
+
   ###
   Returns a new Promise object that's tied to the current Deferred. The doneFilter
-  and failFilter can be used to modify the final values that are passed to the 
+  and failFilter can be used to modify the final values that are passed to the
   callbacks of the new promise. If the parameters passed are falsy, the promise
   object resolves or rejects normally. If the filter functions return a value,
   that one is passed to the respective callbacks. The filters can also return a
@@ -196,9 +196,9 @@ class root.Deferred
               def.rejectWith.call(def, this, failArgs...)
         else
           def.rejectWith.call(def, this, result)
-        def.rejectWith.call(def, this, args...) 
+        def.rejectWith.call(def, this, args...)
       else
-        def.rejectWith.call(def, this, args...) 
+        def.rejectWith.call(def, this, args...)
     def.promise()
 
   ###
@@ -210,13 +210,13 @@ class root.Deferred
     @_progressCallbacks or= []
     @_progressCallbacks.push(functions...)
     this
-  
+
   ###
   Returns the promise object of this Deferred.
   ###
   promise: ->
     @_promise or= new Promise(this)
-  
+
   ###
   Reject this Deferred. If the object has already been rejected or resolved,
   nothing happens. Parameters passed to reject will be handed to all current
@@ -225,7 +225,7 @@ class root.Deferred
   reject: (args...) =>
     @rejectWith(root, args...)
     this
-    
+
   ###
   Reject this Deferred with additional context. Works the same way as reject, except
   the first parameter is used as this when calling the fail and always callbacks.
@@ -240,16 +240,16 @@ class root.Deferred
     @_alwaysCallbacks?.forEach (fn) =>
       fn.apply(@_context, args)
     this
-    
+
   ###
   Resolves this Deferred object. If the object has already been rejected or resolved,
   nothing happens. Parameters passed to resolve will be handed to all current and
-  future done and always callbacks. 
+  future done and always callbacks.
   ###
   resolve: (args...) =>
     @resolveWith(root, args...)
     this
-    
+
   ###
   Resolve this Deferred with additional context. Works the same way as resolve, except
   the first parameter is used as this when calling the done and always callbacks.
@@ -270,7 +270,7 @@ class root.Deferred
   ###
   state: ->
     @_state
-  
+
   ###
   Convenience function to specify each done, fail and progress callbacks at the same time.
   ###
@@ -282,8 +282,8 @@ class root.Deferred
 
 ###
 Returns a new promise object which will resolve when all of the deferreds or promises
-passed to the function resolve. The callbacks receive all the parameters that the 
-individual resolves yielded as an array. If any of the deferreds or promises are 
+passed to the function resolve. The callbacks receive all the parameters that the
+individual resolves yielded as an array. If any of the deferreds or promises are
 rejected, the promise will be rejected immediately.
 ###
 
@@ -293,11 +293,11 @@ root.Deferred.when = (args...) ->
   allReady = new Deferred()
   readyCount = 0
   allDoneArgs = []
-  
+
   args.forEach (dfr, index) ->
     dfr
       .done (doneArgs...) ->
-        readyCount += 1 
+        readyCount += 1
         allDoneArgs[index] = doneArgs
         if readyCount == args.length
           allReady.resolve(allDoneArgs...)

--- a/src/Deferred.coffee
+++ b/src/Deferred.coffee
@@ -33,11 +33,11 @@ flatten = (args) ->
   flatted = []
   args.forEach (item) ->
     if item
-      if typeof item == 'function'
+      if typeof item is 'function'
         flatted.push(item)
       else
         args.forEach (fn) ->
-          if typeof fn == 'function'
+          if typeof fn is 'function'
             flatted.push(fn)
   flatted
 
@@ -84,7 +84,7 @@ class root.Deferred
   ###
   constructor: (fn) ->
     @_state = 'pending'
-    fn.call(this, this) if typeof fn == 'function'
+    fn.call(this, this) if typeof fn is 'function'
 
   ###
   Pass in functions or arrays of functions to be executed when the
@@ -95,9 +95,9 @@ class root.Deferred
   variants are used.
   ###
   always: (args...) =>
-    return this if args.length == 0
+    return this if args.length is 0
     functions = flatten(args)
-    if @_state == 'pending'
+    if @_state is 'pending'
       @_alwaysCallbacks or= []
       @_alwaysCallbacks.push(functions...)
     else
@@ -114,12 +114,12 @@ class root.Deferred
   variant is used.
   ###
   done: (args...) =>
-    return this if args.length == 0
+    return this if args.length is 0
     functions = flatten(args)
-    if @_state == 'resolved'
+    if @_state is 'resolved'
       functions.forEach (fn) =>
         fn.apply(@_context, @_withArguments)
-    else if @_state == 'pending'
+    else if @_state is 'pending'
       @_doneCallbacks or= []
       @_doneCallbacks.push(functions...)
     this
@@ -133,12 +133,12 @@ class root.Deferred
   variant is used.
   ###
   fail: (args...) =>
-    return this if args.length == 0
+    return this if args.length is 0
     functions = flatten(args)
-    if @_state == 'rejected'
+    if @_state is 'rejected'
       functions.forEach (fn) =>
         fn.apply(@_context, @_withArguments)
-    else if @_state == 'pending'
+    else if @_state is 'pending'
       @_failCallbacks or= []
       @_failCallbacks.push(functions...)
     this
@@ -156,7 +156,7 @@ class root.Deferred
   except this is set to context when calling the functions.
   ###
   notifyWith: (context, args...) =>
-    return this if @_state != 'pending'
+    return this if @_state isnt 'pending'
     @_progressCallbacks?.forEach (fn) ->
       fn.apply(context, args)
     this
@@ -205,7 +205,7 @@ class root.Deferred
   Add progress callbacks to be fired when using notify()
   ###
   progress: (args...) =>
-    return this if args.length == 0 or @_state != 'pending'
+    return this if args.length is 0 or @_state isnt 'pending'
     functions = flatten(args)
     @_progressCallbacks or= []
     @_progressCallbacks.push(functions...)
@@ -231,7 +231,7 @@ class root.Deferred
   the first parameter is used as this when calling the fail and always callbacks.
   ###
   rejectWith: (context, args...) =>
-    return this if @_state != 'pending'
+    return this if @_state isnt 'pending'
     @_state = 'rejected'
     @_withArguments = args
     @_context = context
@@ -255,7 +255,7 @@ class root.Deferred
   the first parameter is used as this when calling the done and always callbacks.
   ###
   resolveWith: (context, args...) =>
-    return this if @_state != 'pending'
+    return this if @_state isnt 'pending'
     @_state = 'resolved'
     @_context = context
     @_withArguments = args
@@ -288,8 +288,8 @@ rejected, the promise will be rejected immediately.
 ###
 
 root.Deferred.when = (args...) ->
-  return new Deferred().resolve().promise() if args.length == 0
-  return args[0].promise() if args.length == 1
+  return new Deferred().resolve().promise() if args.length is 0
+  return args[0].promise() if args.length is 1
   allReady = new Deferred()
   readyCount = 0
   allDoneArgs = []
@@ -299,7 +299,7 @@ root.Deferred.when = (args...) ->
       .done (doneArgs...) ->
         readyCount += 1
         allDoneArgs[index] = doneArgs
-        if readyCount == args.length
+        if readyCount is args.length
           allReady.resolve(allDoneArgs...)
       .fail (failArgs...) ->
         allReady.rejectWith(this, failArgs...)

--- a/src/Deferred.coffee
+++ b/src/Deferred.coffee
@@ -94,7 +94,7 @@ class root.Deferred
   is set to the object defined by rejectWith or resolveWith if those
   variants are used.
   ###
-  always: (args...) ->
+  always: (args...) =>
     return this if args.length == 0
     functions = flatten(args)
     if @_state == 'pending'
@@ -113,7 +113,7 @@ class root.Deferred
   to resolve and this is set to the object defined by resolveWith if that
   variant is used.
   ###
-  done: (args...) ->
+  done: (args...) =>
     return this if args.length == 0
     functions = flatten(args)
     if @_state == 'resolved'
@@ -132,7 +132,7 @@ class root.Deferred
   to reject and this is set to the object defined by rejectWith if that
   variant is used.
   ###
-  fail: (args...) ->
+  fail: (args...) =>
     return this if args.length == 0
     functions = flatten(args)
     if @_state == 'rejected'
@@ -147,7 +147,7 @@ class root.Deferred
   Notify progress callbacks. The callbacks get passed the arguments given to notify.
   If the object has resolved or rejected, nothing will happen
   ###
-  notify: (args...) ->
+  notify: (args...) =>
     @notifyWith(root, args...)
     this
 
@@ -155,7 +155,7 @@ class root.Deferred
   Notify progress callbacks with additional context. Works the same way as notify(),
   except this is set to context when calling the functions.
   ###
-  notifyWith: (context, args...) ->
+  notifyWith: (context, args...) =>
     return this if @_state != 'pending'
     @_progressCallbacks?.forEach (fn) ->
       fn.apply(context, args)
@@ -170,7 +170,7 @@ class root.Deferred
   new Promise or Deferred object, of which rejected / resolved will control how the
   callbacks fire.
   ###
-  pipe: (doneFilter, failFilter) ->
+  pipe: (doneFilter, failFilter) =>
     def = new Deferred()
     @done (args...) ->
       if doneFilter?
@@ -204,7 +204,7 @@ class root.Deferred
   ###
   Add progress callbacks to be fired when using notify()
   ###
-  progress: (args...) ->
+  progress: (args...) =>
     return this if args.length == 0 or @_state != 'pending'
     functions = flatten(args)
     @_progressCallbacks or= []
@@ -214,7 +214,7 @@ class root.Deferred
   ###
   Returns the promise object of this Deferred.
   ###
-  promise: ->
+  promise: =>
     @_promise or= new Promise(this)
 
   ###

--- a/src/Deferred.coffee
+++ b/src/Deferred.coffee
@@ -304,3 +304,21 @@ root.Deferred.when = (args...) ->
       .fail (failArgs...) ->
         allReady.rejectWith(this, failArgs...)
   allReady.promise()
+
+# Install Deferred to Zepto automatically.
+do ->
+  destination = window.Zepto
+  return if not destination or destination.Deferred
+  destination.Deferred = ->
+    new Deferred()
+  origAjax = destination.ajax
+  destination.ajax = (options) ->
+    deferred = new Deferred()
+    createWrapper = (wrapped, finisher) ->
+      (args...) ->
+        wrapped?(args...)
+        finisher(args...)
+    options.success = createWrapper options.success, deferred.resolve        
+    options.error = createWrapper options.error, deferred.reject
+    origAjax(options)
+    deferred.promise()


### PR DESCRIPTION
Rewritten in more idiomatic CoffeeScript:
- Use `::` instead of `.prototype`.
- Get rid of standalone `@` because they're not recommended.
- Get rid of brackets. Coffee is whitespace language.
- Use `a?` instead of its javascript idiom.
- Change `||` to `or`, `&&` to `and`.
- Fix `isObservable`, it will work now in minified env.
- Use fat arrows in all cases.
- Replace `==` with `is`, `!=` with `isnt`.

Also:
- Removed trailing whitespace.
- Added Zepto installer.
